### PR TITLE
fix: remove deprecated argparse dependency

### DIFF
--- a/enochecker_cli/__main__.py
+++ b/enochecker_cli/__main__.py
@@ -1,0 +1,4 @@
+from enochecker_cli.base import main
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-argparse>=1.4
 requests>=2.20
 enochecker_core==0.10.0
 jsons>=1.0.0


### PR DESCRIPTION
This pull removes the argparse dependency from requirements.txt, since it is part of the stdlib.

Reference: https://github.com/nix-community/poetry2nix/pull/1654

I've added the `__main__.py` file so that the application can be executed via `python —m enochecker_cli`. If that is not desired, I can remove it.

Tests are passing. Args are parsed as intended. Please confirm.